### PR TITLE
Updated version to 0.0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 PACKAGE_NAME = 'ha-beoplay'
 HERE = os.path.abspath(os.path.dirname(__file__))
-VERSION = '0.0.5'
+VERSION = '0.0.6'
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*', 'dist', 'ccu', 'build'])
 


### PR DESCRIPTION
Updated version to 0.0.6 to reflect changes in the source code and force PyPi to create a new version of the library so that the bug fixes are pulled into home assistant automatically.